### PR TITLE
Added new AgentResponseNode property

### DIFF
--- a/generic_provider/generic_provider.py
+++ b/generic_provider/generic_provider.py
@@ -34,7 +34,6 @@ def wait_event(agent, event, create=False, update=False, delete=False):
     except:
         no_echo = 'false'
     if update:
-        resource_key = 'OldResourceProperties'
         try:
             agent_query_value = event[resource_key]['AgentWaitUpdateQueryValues']
         except:
@@ -240,14 +239,18 @@ def handle_client_event(agent, event, create=False, update=False, delete=False):
             ))
         wait_event(agent, event, create=create, update=update, delete=delete)
         try:
-            responseData = response
-        except:
-            responseData = {}
-        try:
-            PhysicalResourceId = response[agent_resource_id]
+            agent_response_node = event[resource_key]['AgentResponseNode']
+            responseData = response[agent_response_node]
         except:
             try:
-                PhysicalResourceId = jsonpath(response, agent_query_expr)
+                responseData = response
+            except:
+                responseData = {}
+        try:
+            PhysicalResourceId = responseData[agent_resource_id]
+        except:
+            try:
+                PhysicalResourceId = jsonpath(responseData, agent_query_expr)
                 assert PhysicalResourceId
                 PhysicalResourceId = ','.join(PhysicalResourceId)
             except:


### PR DESCRIPTION
I've added a new AgentResponseNode property to the handle_client_event code. 

Reason:
In the current function it was always returning the entire API response into the Data node for cfnresponse. This was causing issues when calling `GetAtt` on the created resource and also prevented `AgentResourceId` from being found in the response without `AgentWaitQueryExpr`.

With this change, you can specify the result node name that you want to extract and return in cfnresponse.

Example:
UserPoolClient:
```yaml
AgentCreateMethod: create_user_pool_client
AgentUpdateMethod: update_user_pool_client
AgentDeleteMethod: delete_user_pool_client
AgentResponseNode: UserPoolClient
AgentResourceId: ClientId
```
previously the result data in cfnresponse would have looked like 
```json
{
  "Data": {
    "UserPoolClient":{
      "ClientId": "abc",
      "ClientName": "name",
      "ClientSecret": "abc123"
    }
  }
}
```
and ClientId would not be found in the dataset as it is nested under UserPoolClient

With this update the result data looks like:
```json
{
  "Data": {
    "ClientId": "abc",
    "ClientName": "name",
    "ClientSecret": "abc123"
  }
}
```
and the `AgentResourceId` will likely be found without needing `AgentWaitQueryExpr`

You can also now use GetAtt to retrieve result data from the resource:
```yaml
UserPoolClientId:
  Value: !GetAtt UserPoolClient.ClientId
UserPoolClientSecret:
  Value: !GetAtt UserPoolClient.ClientSecret
```

I tested this with the existing structure as well to ensure it behaved as it did previously

Note: I also removed another reference to `OldResourceProperties` that I did not see in the first PR