### PR TITLE
Fix for parsing AgentResourceId from JSON string

### DIFF
--- a/generic_provider/generic_provider.py
+++ b/generic_provider/generic_provider.py
@@ -265,7 +265,7 @@ def handle_client_event(agent, event, create=False, update=False, delete=False):
             except:
                 if verbose: print_exc()
                 try:
-                    PhysicalResourceId = event[resource_key][args_key][agent_resource_id]
+                    PhysicalResourceId = agent_kwargs[agent_resource_id]
                     assert PhysicalResourceId, 'PhysicalResourceId from event[resource_key][args_key][agent_resource_id]'
                 except:
                     if verbose: print_exc()


### PR DESCRIPTION
I discovered an issue when using `!Sub |` syntax, which results in a string of JSON instead of standard JSON. This logic to parse out the `AgentResourceId` from the request only worked when the Args is standard JSON and not a string of JSON.

With this update, it uses the agent_kwargs which has already been properly parsed from either the JSON or string of JSON at the beginning of the function call.

This was the issue I was going to open earlier, but I ended up figuring it out.